### PR TITLE
Update TestrailReporter.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pm.test("C226750 C226746 Status code is 200", function () {
 | TESTRAIL_FAILED_ID | The ID of a custom status to use for Failed.  Defaults to 5 which is the value for the Failed status. |
 | TESTRAIL_SKIPPED_ID | The ID of a custom status to use for Skipped.  Defaults to 4 which is the value for the Skipped status. |
 | TESTRAIL_STEPS | Project uses test steps.  Test cases that share the same case id are assumed to be steps for the same test case.  Defaults to false. |
-| TESTRAIL_STEPRESULT_KEY | If the TESTRAIL_STEPS is set to true and your TestRail configuration changed the custom_step_results to another name then you can set this env variable to the correct name.  By default this is set to "custom_step_results". |
+| TESTRAIL_STEPRESULT_KEY | If TESTRAIL_STEPS is set to true and your TestRail configuration changed the custom_step_results to another name then you can set this env variable to the correct name.  By default this is set to "custom_step_results". |
 
 
 You can use [direnv](https://github.com/direnv/direnv) to easily maintain directory-specific options.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pm.test("C226750 C226746 Status code is 200", function () {
 | TESTRAIL_FAILED_ID | The ID of a custom status to use for Failed.  Defaults to 5 which is the value for the Failed status. |
 | TESTRAIL_SKIPPED_ID | The ID of a custom status to use for Skipped.  Defaults to 4 which is the value for the Skipped status. |
 | TESTRAIL_STEPS | Project uses test steps.  Test cases that share the same case id are assumed to be steps for the same test case.  Defaults to false. |
-| TESTRAIL_STEPRESULT_KEY | If TESTRAIL_STEPS is set to true and your TestRail configuration changed the custom_step_results to another name then you can set this env variable to the correct name.  By default this is set to "custom_step_results". |
+| TESTRAIL_STEPRESULT_KEY | If TESTRAIL_STEPS is set to true and your TestRail configuration changed the Step Results field to another value then you can set this env variable to the correct name.  By default this is set to "step_results". |
 
 
 You can use [direnv](https://github.com/direnv/direnv) to easily maintain directory-specific options.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pm.test("C226750 C226746 Status code is 200", function () {
 | TESTRAIL_FAILED_ID | The ID of a custom status to use for Failed.  Defaults to 5 which is the value for the Failed status. |
 | TESTRAIL_SKIPPED_ID | The ID of a custom status to use for Skipped.  Defaults to 4 which is the value for the Skipped status. |
 | TESTRAIL_STEPS | Project uses test steps.  Test cases that share the same case id are assumed to be steps for the same test case.  Defaults to false. |
+| TESTRAIL_STEPRESULT_KEY | If the TESTRAIL_STEPS is set to true and your TestRail configuration changed the custom_step_results to another name then you can set this env variable to the correct name.  By default this is set to "custom_step_results". |
 
 
 You can use [direnv](https://github.com/direnv/direnv) to easily maintain directory-specific options.

--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -127,7 +127,7 @@ class TestRailReporter {
               (result) => result.case_id === currentResult.case_id,
             );
             if (parentIndex === -1) {
-              currentStepResult.custom_step_results = [
+              currentStepResult.custom_step_result = [
                 {
                   status_id: currentStepResult.status_id,
                   content: currentStepResult.comment,
@@ -136,8 +136,8 @@ class TestRailReporter {
               delete currentStepResult.comment;
               this.results.push(currentStepResult);
             } else {
-              // If a parent case exists, we can just push the new result to custom_step_results
-              this.results[parentIndex].custom_step_results.push({
+              // If a parent case exists, we can just push the new result to custom_step_result
+              this.results[parentIndex].custom_step_result.push({
                 status_id: currentStepResult.status_id,
                 content: currentStepResult.comment,
               });
@@ -166,7 +166,7 @@ class TestRailReporter {
     else {
       this.results = this.results.map((result) => {
         if (
-          result.custom_step_results.some(
+          result.custom_step_result.some(
             (step) => step.status_id === this.env.fail_id,
           )
         ) {

--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -127,7 +127,7 @@ class TestRailReporter {
               (result) => result.case_id === currentResult.case_id,
             );
             if (parentIndex === -1) {
-              currentStepResult.custom_step_result = [
+              currentStepResult[this.env.stepResultKey] = [
                 {
                   status_id: currentStepResult.status_id,
                   content: currentStepResult.comment,
@@ -137,7 +137,7 @@ class TestRailReporter {
               this.results.push(currentStepResult);
             } else {
               // If a parent case exists, we can just push the new result to custom_step_result
-              this.results[parentIndex].custom_step_result.push({
+              this.results[parentIndex][this.env.stepResultKey].push({
                 status_id: currentStepResult.status_id,
                 content: currentStepResult.comment,
               });
@@ -166,7 +166,7 @@ class TestRailReporter {
     else {
       this.results = this.results.map((result) => {
         if (
-          result.custom_step_result.some(
+          result[this.env.stepResultKey].some(
             (step) => step.status_id === this.env.fail_id,
           )
         ) {

--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -136,7 +136,7 @@ class TestRailReporter {
               delete currentStepResult.comment;
               this.results.push(currentStepResult);
             } else {
-              // If a parent case exists, we can just push the new result to custom_step_result
+              // If a parent case exists, we can just push the new result to custom_step_results
               this.results[parentIndex][this.env.stepResultKey].push({
                 status_id: currentStepResult.status_id,
                 content: currentStepResult.comment,

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -15,6 +15,7 @@ function getEnv() {
   env.pass_id = process.env.TESTRAIL_PASSED_ID || 1;
   env.fail_id = process.env.TESTRAIL_FAILED_ID || 5;
   env.skipped_id = process.env.TESTRAIL_SKIPPED_ID || 4;
+  env.stepResultKey = `custom_${process.env.TESTRAIL_STEPRESULT_KEY || 'step_results'}`;
   env.customKeys = Object.keys(process.env).filter((key) =>
     key.startsWith('TESTRAIL_CUSTOM'),
   );


### PR DESCRIPTION
The TestRail API is incorrectly documented in the TestRail docs.  Instead of "custom_step_results" it is "custom_step_result".  Without the "s" on the end.  I made this change locally and it seemed to work.