### PR TITLE
TESTRAIL_TITLE_MATCHING  check if 'true'

### DIFF
--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -42,7 +42,7 @@ class TestRailReporter {
       return testExecution.assertions && testExecution.assertions.length > 0;
     });
 
-    if (this.env.useTitles) {
+    if (this.env.useTitles.toLowerCase() === 'true') {
       const testRailApi = new TestRailApi();
       const allCases = testRailApi.getCases();
       filteredExecutions.forEach((execution) => {


### PR DESCRIPTION
In order to resolve issue https://github.com/billylam/newman-reporter-testrail/issues/40 a proposed change is implemented.
TESTRAIL_TITLE_MATCHING  environment variable will be used only if it is set to 'true'.