### PR TITLE
Search assertions by execution item name

### DIFF
--- a/lib/TestrailReporter.js
+++ b/lib/TestrailReporter.js
@@ -49,7 +49,9 @@ class TestRailReporter {
       filteredExecutions.forEach((execution) => {
         execution.assertions.forEach((assertion) => {
           const match = allCases.find(
-            (testCase) => testCase.title === assertion.assertion,
+            (testCase) =>
+                testCase.title === assertion.assertion || 
+                testCase.title === execution.item.name,
           );
 
           if (match)


### PR DESCRIPTION
Let reporter search corresponding assertions not only by assertion title, but by execution item (request) name also.